### PR TITLE
[update]#4 Merge時にPrefix checkが走らないようにする

### DIFF
--- a/commit_msg/prefix_and_issue_num.py
+++ b/commit_msg/prefix_and_issue_num.py
@@ -30,13 +30,13 @@ def main():
         'add/',
         'remove/',
     ]
-    merge_prefix = ['[fix]', '[update]', '[add]', '[remove]', 'Merge', 'Revert']
+    merge_match_ptn = r'(\[fix\]|\[update\]|\[add\]|\[remove\]|Merge|Revert)'
 
     git_dir = commit_msg_file = pathlib.Path('./.git/')
     commit_msg_file = pathlib.Path(git_dir/'COMMIT_EDITMSG')
     commit_msg = commit_msg_file.read_text(encoding='utf-8')
     head = pathlib.Path(git_dir/'HEAD').read_text(encoding='utf-8')
-    not_merge = commit_msg[0:re.search(r'(#|\s)', commit_msg).start()] in merge_prefix
+    not_merge = bool(re.search(merge_match_ptn, commit_msg))
 
     # ブランチ名チェック
     # イシュー番号付与チェック

--- a/commit_msg/prefix_and_issue_num.py
+++ b/commit_msg/prefix_and_issue_num.py
@@ -30,12 +30,13 @@ def main():
         'add/',
         'remove/',
     ]
+    merge_prefix = ['[fix]', '[update]', '[add]', '[remove]', 'Merge', 'Revert']
 
     git_dir = commit_msg_file = pathlib.Path('./.git/')
     commit_msg_file = pathlib.Path(git_dir/'COMMIT_EDITMSG')
     commit_msg = commit_msg_file.read_text(encoding='utf-8')
     head = pathlib.Path(git_dir/'HEAD').read_text(encoding='utf-8')
-    not_merge = commit_msg[0:commit_msg.find(' ')] != 'Merge'
+    not_merge = commit_msg[0:re.search(r'(#|\s)', commit_msg).start()] in merge_prefix
 
     # ブランチ名チェック
     # イシュー番号付与チェック


### PR DESCRIPTION
#4 の対応です。
マージするときにprefixチェックでエラーになって止まるのが鬱陶しいので止まらないようにしました。